### PR TITLE
add lambda name (no AWS prefix)

### DIFF
--- a/lib/batchtask.js
+++ b/lib/batchtask.js
@@ -166,7 +166,7 @@ function updateContainerProperties(newFunction, functionObject, functionName) {
       AWS_LAMBDA_FUNCTION_TIMEOUT: getTimeout(functionObject),
       AWS_LAMBDA_FUNCTION_MEMORY_SIZE: getMemorySize(functionObject),
       AWS_REGION: this.serverless.service.provider.region || 'us-east-1',
-      AWS_BATCH_LAMBDA_NAME: `${functionName}-batch`,
+      BATCH_LAMBDA_NAME: `${functionName}-batch`,
     },
     this.serverless.service.provider.environment,
     functionObject.environment,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cellense/serverless-aws-batch",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Serverless Framework Plugin for interacting with AWS Batch",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
just fixing passing lambda name for function.
yesterday I accidentaly pushed directly to master (I forgot I am not working on this anymore). However there was only single line added (line 169)